### PR TITLE
Updated details of edgeware's lockdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       The lockdrop is now open using the Edgeware website at:
       <a href="https://edgewa.re/lockdrop">edgewa.re/lockdrop</a>!
       </br>
-      Current 23% locking bonus in effect through <a href="https://blog.edgewa.re/final-terms-and-updates-to-the-edgeware-lockdrop/">July 15</a>.
+      14% locking bonus is in effect through <a href="https://blog.edgewa.re/final-terms-and-updates-to-the-edgeware-lockdrop/">July 30, 00:00 UTC</a>.
     </div>
   </div>
 


### PR DESCRIPTION
A new bonus phase began on 15 July.

This PR updates the content on straighted.ge to reflect this.