### PR TITLE
Update link from WP V.099 to 1.02

### DIFF
--- a/edgeware-whitepaper/index.html
+++ b/edgeware-whitepaper/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="Refresh" content="5; url=https://arena-attachments.s3.amazonaws.com/4282259/789835ae15b3f6fb5ea702f13544fabf.pdf?1557961331">
+<meta http-equiv="Refresh" content="5; url=https://arena-attachments.s3.amazonaws.com/4643268/c8d128724f36b716660e4bf21823e760.pdf?1563310093">


### PR DESCRIPTION
Updated the link to the Edgeware whitepaper to be up-to-date.