### PR TITLE
FAQs - Telegram >> Discord (Chat)

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -60,11 +60,11 @@
         <ul id="menu">
           <li><a class="i18n" href="/">Home</a></li>
           <li><a class="i18n" href="/faq">FAQ</a></li>
-          <li><a class="i18n" href="https://t.me/HeyStraightedge">Telegram</a></li>
+          <li><a class="i18n" href="https://discord.gg/akVk9PT">Chat</a></li>
           <li><a class="i18n" href="https://twitter.com/heystraightedge">Twitter</a></li>
           <li><a class="i18n wp" href="https://arena-attachments.s3.amazonaws.com/4283183/6f6c1e4dd35661c6e0eb001caa537ac3.pdf?1557976574"
              target="_blank">Whitepaper</a></li>
-          <li><a class="i18n" href="https://github.com/sikkatech/straightedge-node" target="_blank">Github</a></li>
+          <li><a class="i18n" href="https://github.com/heystraightedge/straightedge-node" target="_blank">Github</a></li>
           <br>
           <li class="i18n-selector"></li>
         </ul>
@@ -82,13 +82,13 @@
       <div class="header-links">
         <a class="i18n wp" href="/">Home</a>
         &middot;
-        <a class="i18n wp" href="https://t.me/HeyStraightedge" target="_blank">Telegram</a>
+        <a class="i18n wp" href="https://discord.gg/akVk9PT" target="_blank">Chat</a>
         &middot;
         <a class="i18n wp" href="https://twitter.com/heystraightedge" target="_blank">Twitter</a>
         &middot;
         <a class="i18n wp" href="https://arena-attachments.s3.amazonaws.com/4283183/6f6c1e4dd35661c6e0eb001caa537ac3.pdf?1557976574" target="_blank">Edgeware Whitepaper</a>
         &middot;
-        <a class="i18n" href="https://github.com/sikkatech/straightedge-node" target="_blank">Github</a>
+        <a class="i18n" href="https://github.com/heystraightedge/straightedge-node" target="_blank">Github</a>
         <!-- &middot;
         <a class="i18n" href="https://twitter.com/heystraightedge" target="_blank">Twitter</a>
         &middot;
@@ -128,7 +128,7 @@
       <div class="container">
         <div class="row">
           <div class="footer-links">
-            <a class="i18n wp" href="https://t.me/HeyStraightedge" target="_blank">Telegram</a>
+            <a class="i18n wp" href="https://discord.gg/akVk9PT" target="_blank">Chat</a>
             &middot;
             <a class="i18n wp" href="https://twitter.com/heystraightedge" target="_blank">Twitter</a>
             &middot;
@@ -136,7 +136,7 @@
             &middot;
             <a class="i18n" href="/faq">FAQs</a>
             &middot;
-            <a class="i18n" href="https://github.com/sikkatech/straightedge-node" target="_blank">Github</a>
+            <a class="i18n" href="https://github.com/heystraightedge/straightedge-node" target="_blank">Github</a>
           </div>
           <div class="footer copyright">&copy; 2019 <span class="i18n">Straightedge Team</span></div></div>
       </div>


### PR DESCRIPTION
Removed references to Telegram, and replaced with "Chat" and a link to Discord